### PR TITLE
Add instructions on how to set default user and password

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -68,6 +68,14 @@ You can access it by visiting `http://container-ip:15672` in a browser or, if yo
 
 You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser.
 
+## Setting default user and password
+
+If you wish to change the default username and password of `guest` / `guest`, you can do so with the `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS` environmental variables:
+
+     docker run -d --hostname my-rabbit --name some-rabbit -e RABBITMQ_DEFAULT_USER=user -e RABBITMQ_DEFAULT_PASS=password rabbitmq:3-management
+    
+You can then go to `http://localhost:8080` or `http://host-ip:8080` in a browser and use `user`/`password` to gain access to the management console
+
 ## Connecting to the daemon
 
 	docker run --name some-app --link some-rabbit:rabbit -d application-that-uses-rabbitmq


### PR DESCRIPTION
Include instructions on README showing how to use RABBITMQ_DEFAULT_USER and RABBITMQ_DEFAULT_PASS environmental variables
